### PR TITLE
Lambda function to block public S3 access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,9 +49,9 @@ module "cloudwatch" {
 module "lambdas" {
   source = "./modules/lambdas"
 
-  region                                   = var.region
-  enable_lambdas                           = var.enable_lambdas
-  slack_topic_arn                          = module.slack_integration.this_slack_topic_arn
-  s3_bucket_enforce_encryption_exceptions  = var.s3_bucket_enforce_encryption_exceptions
-  s3_bucket_block_publickaccess_exceptions = var.s3_bucket_block_publickaccess_exceptions
+  region                                  = var.region
+  enable_lambdas                          = var.enable_lambdas
+  slack_topic_arn                         = module.slack_integration.this_slack_topic_arn
+  s3_bucket_enforce_encryption_exceptions = var.s3_bucket_enforce_encryption_exceptions
+  s3_bucket_block_publicaccess_exceptions = var.s3_bucket_block_publicaccess_exceptions
 }

--- a/main.tf
+++ b/main.tf
@@ -49,8 +49,9 @@ module "cloudwatch" {
 module "lambdas" {
   source = "./modules/lambdas"
 
-  region                                  = var.region
-  enable_lambdas                          = var.enable_lambdas
-  slack_topic_arn                         = module.slack_integration.this_slack_topic_arn
-  s3_bucket_enforce_encryption_exceptions = var.s3_bucket_enforce_encryption_exceptions
+  region                                   = var.region
+  enable_lambdas                           = var.enable_lambdas
+  slack_topic_arn                          = module.slack_integration.this_slack_topic_arn
+  s3_bucket_enforce_encryption_exceptions  = var.s3_bucket_enforce_encryption_exceptions
+  s3_bucket_block_publickaccess_exceptions = var.s3_bucket_block_publickaccess_exceptions
 }

--- a/modules/lambdas/functions/s3-bucket-block-publicaccess/index.py
+++ b/modules/lambdas/functions/s3-bucket-block-publicaccess/index.py
@@ -1,0 +1,104 @@
+#==================================================================================================
+# Function: 
+# Purpose:  A Python function to list out any AWS S3 buckets in the account that have 
+# public access based on their ACLs, either Read or Write permissions.
+#==================================================================================================
+
+import boto3, json, datetime, os, sys
+from time import gmtime, strftime
+from datetime import date
+
+#==================================================================================================
+# Function handler
+#==================================================================================================
+def lambda_handler(event, context):
+
+    private_buckets = {} 
+    private_buckets['PublicAccessBlock'] = []
+    date_fmt = strftime("%d_%m_%Y_%H:%M:%S", gmtime())              #get to the current date
+    sns_topic_arn = os.environ['TOPIC_ARN']
+    sns_topic_region = os.environ['TOPIC_REGION']
+    s3_bucket_exception_list = os.environ['S3_EXCEPTION']
+    account_id = context.invoked_function_arn.split(":")[4]
+
+    s3client = boto3.client('s3')
+
+    public_acl_indicator = ['http://acs.amazonaws.com/groups/global/AllUsers','http://acs.amazonaws.com/groups/global/AuthenticatedUsers']
+    permissions_to_check = ['READ', 'WRITE']
+    public_buckets = {}
+    print(boto3.__version__)
+    
+    try:
+        # describe all S3 buckets
+        list_bucket_response = s3client.list_buckets()
+        for bucket_dictionary in list_bucket_response['Buckets']:
+            if bucket_dictionary['Name'] not in s3_bucket_exception_list:
+                is_public_bucket = "false"
+                bucket_acl_response = s3client.get_bucket_acl(Bucket=bucket_dictionary['Name'])
+                for grant in bucket_acl_response['Grants']:
+                    for (key, value) in grant.items():
+                        if key == 'Permission' and any(permission in value for permission in permissions_to_check):
+                            for (grantee_attrib_key, grantee_attrib_value) in grant['Grantee'].items():
+                                if 'URI' in grantee_attrib_key and grant['Grantee']['URI'] in public_acl_indicator:
+                                    is_public_bucket = "true"
+                                    if value not in public_buckets:
+                                        public_buckets[value] = [bucket_dictionary['Name']]
+                                    else:
+                                        public_buckets[value] += [bucket_dictionary['Name']]
+                # If bucket is private
+                if (is_public_bucket == "false"):
+                    print ("\nbucket {0} is PRIVATE".format(bucket_dictionary['Name']))
+                    try:
+                        response = s3client.get_public_access_block(Bucket=bucket_dictionary['Name'])
+                        count = 0
+                        for key, value in response['PublicAccessBlockConfiguration'].items():
+                            # print ("public access block {0} {1} ".format(key, value))
+                            if ( str(value) == "False" ):
+                                print ("public access block already configured but set to false. changing permissions to true")
+                                response = s3client.put_public_access_block(
+                                    Bucket=bucket_dictionary['Name'],
+                                    PublicAccessBlockConfiguration={
+                                        'BlockPublicAcls': True,
+                                        'IgnorePublicAcls': True,
+                                        'BlockPublicPolicy': True,
+                                        'RestrictPublicBuckets': True
+                                })
+                                print ("public access block applied")
+                                private_buckets['PublicAccessBlock'].append(bucket_dictionary['Name'])
+                                break
+                            else:
+                                count += 1
+                        if (count == 4):
+                            print ("{0} has public access block correctly configured".format(bucket_dictionary['Name']))
+                    except:
+                        response = s3client.put_public_access_block(
+                            Bucket=bucket_dictionary['Name'],
+                            PublicAccessBlockConfiguration={
+                                'BlockPublicAcls': True,
+                                'IgnorePublicAcls': True,
+                                'BlockPublicPolicy': True,
+                                'RestrictPublicBuckets': True
+                            })
+                        print ("public access block applied")
+                        private_buckets['PublicAccessBlock'].append(bucket_dictionary['Name'])
+                else:
+                    print ("\nbucket {0} is PUBLIC, skip public access block".format(bucket_dictionary['Name']))
+
+        print("\nPrivate Buckets that have been updated with Public Access Block permissions are {0}".format(private_buckets['PublicAccessBlock']))
+
+        if (private_buckets['PublicAccessBlock'] == []):
+            print ("Nothing to SNS")
+        else:
+            # SNS topic Section
+            sns_client       = boto3.client('sns',region_name=sns_topic_region)
+            subject          = 'AWS Account - ' + account_id + ' S3 Bucket Status ' + date_fmt
+            message_body     = '\n' + "S3 Private Buckets updated with Public Access Block permissions " + str(private_buckets)
+            sns_client.publish(TopicArn=sns_topic_arn, Message=message_body, Subject=subject)
+        
+        return public_buckets
+
+    except:
+        err = 'Error'
+        for e in sys.exc_info():
+            err += str(e)
+        print("error {0}".format(err))

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -17,6 +17,87 @@ data "aws_iam_policy_document" "lambda_assume" {
   }
 }
 
+#######################################################
+# S3 Bucket - Check and enforce against Public Access #
+#######################################################
+
+data "aws_iam_policy_document" "s3_bucket_publicaccess_permissions" {
+  statement {
+    sid    = "ListBucketPermissions"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:GetBucketPolicyStatus",
+      "s3:GetBucketPolicy",
+      "s3:GetBucketPublicAccessBlock",
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:PutBucketPublicAccessBlock"
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+
+  statement {
+    sid    = "SnsPublishPermissions"
+    effect = "Allow"
+
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      var.slack_topic_arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "s3_bucket_publicaccess_permissions" {
+  name   = "s3-bucket-publicaccess-and-sns"
+  role   = aws_iam_role.s3_bucket_block_publicaccess.id
+  policy = data.aws_iam_policy_document.s3_bucket_publicaccess_permissions.json
+}
+
+resource "aws_iam_role_policy" "s3_bucket_publicaccess_lambda_policy" {
+  name   = "s3-bucket-publicaccess-basic-execution-role"
+  role   = aws_iam_role.s3_bucket_block_publicaccess.id
+  policy = data.aws_iam_policy.AWSLambdaBasicExecutionRole.policy
+}
+
+resource "aws_iam_role" "s3_bucket_block_publicaccess" {
+  name               = "s3-bucket-publicaccess"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+data "archive_file" "s3_bucket_block_publicaccess_zip" {
+  type        = "zip"
+  source_file = "${path.module}/functions/s3-bucket-block-publicaccess/index.py"
+  output_path = "${path.module}/files/s3-bucket-block-publicaccess.zip"
+}
+
+resource "aws_lambda_function" "s3_bucket_block_publicaccess" {
+  filename      = "${path.module}/files/s3-bucket-block-publicaccess.zip"
+  function_name = "S3BucketBlockPublicAccess"
+  description   = "Determine the list of S3 private buckets and apply Public Access Block permissions"
+  handler       = "index.lambda_handler"
+  role          = aws_iam_role.s3_bucket_block_publicaccess.arn
+  runtime       = "python3.6"
+  timeout       = 600
+
+  environment {
+    variables = {
+      TOPIC_ARN    = var.slack_topic_arn
+      TOPIC_REGION = var.region
+      S3_EXCEPTION = join(" ", var.s3_bucket_block_publickaccess_exceptions)
+    }
+  }
+
+  depends_on = [data.archive_file.s3_bucket_block_publicaccess_zip]
+}
+
 ############################################
 # S3 Bucket - Check and Enforce Encryption #
 ############################################
@@ -80,6 +161,7 @@ data "archive_file" "s3_bucket_encryption_zip" {
 resource "aws_lambda_function" "s3_bucket_encryption" {
   filename      = "${path.module}/files/s3-bucket-enable-default-encryption.zip"
   function_name = "S3BucketEncryption"
+  description   = "Determine the list of S3 buckets that are not encrypted and apply default encryption"
   handler       = "index.lambda_handler"
   role          = aws_iam_role.s3_bucket_encryption.arn
   runtime       = "python3.6"
@@ -110,4 +192,16 @@ resource "aws_cloudwatch_event_target" "s3_bucket_encryption" {
   rule      = aws_cloudwatch_event_rule.s3_bucket_encryption.name
   target_id = "lambda"
   arn       = aws_lambda_function.s3_bucket_encryption.arn
+}
+
+resource "aws_cloudwatch_event_rule" "s3_bucket_block_publicaccess" {
+  name                = "S3Bucket-BluckPublicAccess"
+  description         = "Determine the list of S3 private buckets and apply Public Access Block permissions"
+  schedule_expression = "cron(0 12 ? * WED *)"
+}
+
+resource "aws_cloudwatch_event_target" "s3_bucket_block_publicaccess" {
+  rule      = aws_cloudwatch_event_rule.s3_bucket_block_publicaccess.name
+  target_id = "lambda"
+  arn       = aws_lambda_function.s3_bucket_block_publicaccess.arn
 }

--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -91,7 +91,7 @@ resource "aws_lambda_function" "s3_bucket_block_publicaccess" {
     variables = {
       TOPIC_ARN    = var.slack_topic_arn
       TOPIC_REGION = var.region
-      S3_EXCEPTION = join(" ", var.s3_bucket_block_publickaccess_exceptions)
+      S3_EXCEPTION = join(" ", var.s3_bucket_block_publicaccess_exceptions)
     }
   }
 

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -14,6 +14,6 @@ variable "s3_bucket_enforce_encryption_exceptions" {
   type = list(string)
 }
 
-variable "s3_bucket_block_publickaccess_exceptions" {
+variable "s3_bucket_block_publicaccess_exceptions" {
   type = list(string)
 }

--- a/modules/lambdas/variables.tf
+++ b/modules/lambdas/variables.tf
@@ -13,3 +13,7 @@ variable "region" {
 variable "s3_bucket_enforce_encryption_exceptions" {
   type = list(string)
 }
+
+variable "s3_bucket_block_publickaccess_exceptions" {
+  type = list(string)
+}

--- a/modules/logging/main.tf
+++ b/modules/logging/main.tf
@@ -122,7 +122,7 @@ resource "aws_s3_bucket" "cloudtraillogs" {
 resource "aws_s3_bucket_public_access_block" "cloudtraillogs" {
   count = var.enable_logging ? 1 : 0
 
-  bucket = aws_s3_bucket.cloudtraillogs.0.id
+  bucket                  = aws_s3_bucket.cloudtraillogs.0.id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -245,7 +245,7 @@ resource "aws_s3_bucket" "configlogs" {
 resource "aws_s3_bucket_public_access_block" "configlogs" {
   count = var.enable_logging ? 1 : 0
 
-  bucket = aws_s3_bucket.configlogs.0.id
+  bucket                  = aws_s3_bucket.configlogs.0.id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -314,7 +314,7 @@ resource "aws_s3_bucket" "accesslogs" {
 resource "aws_s3_bucket_public_access_block" "accesslogs" {
   count = var.enable_logging ? 1 : 0
 
-  bucket = aws_s3_bucket.accesslogs.0.id
+  bucket                  = aws_s3_bucket.accesslogs.0.id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true

--- a/modules/logging/main.tf
+++ b/modules/logging/main.tf
@@ -119,6 +119,16 @@ resource "aws_s3_bucket" "cloudtraillogs" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "cloudtraillogs" {
+  count = var.enable_logging ? 1 : 0
+
+  bucket = aws_s3_bucket.cloudtraillogs.0.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 ###############
 # Config Logs #
 ###############
@@ -232,6 +242,16 @@ resource "aws_s3_bucket" "configlogs" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "configlogs" {
+  count = var.enable_logging ? 1 : 0
+
+  bucket = aws_s3_bucket.configlogs.0.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 ###############
 # Access Logs #
 ###############
@@ -289,6 +309,16 @@ resource "aws_s3_bucket" "accesslogs" {
   }
 
   tags = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "accesslogs" {
+  count = var.enable_logging ? 1 : 0
+
+  bucket = aws_s3_bucket.accesslogs.0.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 ##############

--- a/modules/logging/outputs.tf
+++ b/modules/logging/outputs.tf
@@ -1,5 +1,5 @@
 
 output "buckets" {
   description = "Buckets created for all account logs related"
-  value       = [ aws_s3_bucket.cloudtraillogs.*.id , aws_s3_bucket.configlogs.*.id , aws_s3_bucket.accesslogs.*.id ]
+  value       = [aws_s3_bucket.cloudtraillogs.*.id, aws_s3_bucket.configlogs.*.id, aws_s3_bucket.accesslogs.*.id]
 }

--- a/modules/logging/variables.tf
+++ b/modules/logging/variables.tf
@@ -16,9 +16,9 @@ variable "region" {
 }
 
 variable "cloudtrail_name" {
-  type        = string
+  type = string
 }
 
 variable "enable_logging" {
-  type        = bool
+  type = bool
 }

--- a/variables.tf
+++ b/variables.tf
@@ -78,4 +78,10 @@ variable "s3_bucket_enforce_encryption_exceptions" {
   default     = [""]
   description = "S3 buckets exceptions for encryption remediation"
 }
+
+variable "s3_bucket_block_publickaccess_exceptions" {
+  type        = list(string)
+  default     = [""]
+  description = "S3 buckets exceptions for publicaccess remediation"
+}
 # END: lambdas module

--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "s3_bucket_enforce_encryption_exceptions" {
   description = "S3 buckets exceptions for encryption remediation"
 }
 
-variable "s3_bucket_block_publickaccess_exceptions" {
+variable "s3_bucket_block_publicaccess_exceptions" {
   type        = list(string)
   default     = [""]
   description = "S3 buckets exceptions for publicaccess remediation"


### PR DESCRIPTION
Added new lambda function to block public access for buckets unless they are within exceptions (`s3_bucket_block_publickaccess_exceptions`)

It was also added default ACL permissions for loggings buckets (accesslog, configlog, cloudtrail). The fact they don't have it make them private but it is a good practice being explicit.

