### PR TITLE
Output slack_sns_topic ARN

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,3 +3,8 @@ output "logging_buckets" {
   description = "Buckets created for all account logs related"
   value       = module.logging.buckets
 }
+
+output "slack_sns_topic" {
+  description = "Slack integration sns topic name"
+  value       = module.slack_integration.this_slack_topic_arn
+}


### PR DESCRIPTION
This needs to be read by remote sources, such as Elasticsearch.