### PR TITLE
Bump terraform-aws-modules/notify-slack/aws to v5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "logging" {
 
 module "slack_integration" {
   source  = "terraform-aws-modules/notify-slack/aws"
-  version = "~> v4.0"
+  version = "~> v5.0"
 
   create = var.enable_slack_integration
 


### PR DESCRIPTION
This PR bumps `terraform-aws-modules/notify-slack/aws` from `v4` to `v5`.

The only noteworthy change is that the `notify_slack` function now supports [AWS Health](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/compare/v4.24.0...v5.3.0#diff-bd166a3516b840738040d77e567a01c01bcb113d28b1ce0bef03cc5897022f67). Apart from that, this is no-op.