### PR TITLE
Add a resource for IAM Access Analyzer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,3 +38,10 @@ module "lambdas" {
   s3_bucket_enforce_encryption_exceptions = var.s3_bucket_enforce_encryption_exceptions
   s3_bucket_block_publicaccess_exceptions = var.s3_bucket_block_publicaccess_exceptions
 }
+
+module "access_analyzer" {
+  source               = "./modules/access-analyzer"
+  access_analyzer_name = "account-analyzer"
+
+  tags = var.tags
+}

--- a/modules/access-analyzer/main.tf
+++ b/modules/access-analyzer/main.tf
@@ -1,0 +1,5 @@
+resource "aws_accessanalyzer_analyzer" "example" {
+  analyzer_name = var.access_analyzer_name
+
+  tags = var.tags
+}

--- a/modules/access-analyzer/variables.tf
+++ b/modules/access-analyzer/variables.tf
@@ -1,0 +1,9 @@
+variable "access_analyzer_name" {
+  type        = string
+  description = "Name of the Access Analyzer"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags"
+}

--- a/modules/access-analyzer/versions.tf
+++ b/modules/access-analyzer/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
+  }
+  required_version = ">= 0.14"
+}


### PR DESCRIPTION
This PR creates an account-level [IAM Access Analyzer](https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html) to enable us to audit outside account access.