### PR TITLE
Bump python from 3.6 - 3.9

### DIFF
--- a/modules/lambdas/main.tf
+++ b/modules/lambdas/main.tf
@@ -84,7 +84,7 @@ resource "aws_lambda_function" "s3_bucket_block_publicaccess" {
   description   = "Determine the list of S3 private buckets and apply Public Access Block permissions"
   handler       = "index.lambda_handler"
   role          = aws_iam_role.s3_bucket_block_publicaccess.arn
-  runtime       = "python3.6"
+  runtime       = "python3.9"
   timeout       = 600
 
   environment {
@@ -164,7 +164,7 @@ resource "aws_lambda_function" "s3_bucket_encryption" {
   description   = "Determine the list of S3 buckets that are not encrypted and apply default encryption"
   handler       = "index.lambda_handler"
   role          = aws_iam_role.s3_bucket_encryption.arn
-  runtime       = "python3.6"
+  runtime       = "python3.9"
   timeout       = 600
 
   environment {


### PR DESCRIPTION
The lambda runner has to be on python 3.9 as 3.6 is no longer supported.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

Terraform error: ```The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions."```
